### PR TITLE
Fix decimal_separator validation to accept empty string

### DIFF
--- a/parseur/schemas/mailbox.py
+++ b/parseur/schemas/mailbox.py
@@ -30,7 +30,7 @@ class MailboxSchema(BaseSchema):
     # ################
     decimal_separator = fields.String(
         allow_none=True,
-        validate=validate.OneOf([".", ","], error="Must be '.' or ',' or null."),
+        validate=validate.OneOf([".", ",", ""], error="Must be '.', ',' or null."),
     )
     default_timezone = fields.String(allow_none=True)
 


### PR DESCRIPTION
## Problem

The `decimal_separator` field in `MailboxSchema` was failing validation when the API returned an empty string (`""`).

The validator only allowed `"."` or `","` (plus `None` via `allow_none=True`), causing a `ValidationError`:

```
marshmallow.exceptions.ValidationError: {'decimal_separator': ["Must be '.' or ',' or null."]}
```

## Solution

Added empty string to the allowed values in the `OneOf` validator.

## Testing

Verified the fix works against a live mailbox that returns `decimal_separator: ""`.